### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(name='Umklapp',
       packages=find_packages(),
       include_package_data=True,
       description='A Story-Continuation Game',
-      install_requires=open('%s/requirements.txt' %
+      install_requires=open('{0!s}/requirements.txt'.format(
                             os.environ.get('OPENSHIFT_REPO_DIR',
                                            PROJECT_ROOT
-                                          )
+                                          ))
                            ).readlines(),
      )

--- a/umklapp/tests.py
+++ b/umklapp/tests.py
@@ -25,14 +25,14 @@ class SkipVoteTest(TestCase):
     def testSafeMajority(self):
         for total in range(3,100):
             necVote = necessary_skip_votes(total)
-            self.assertTrue(necVote > 0.5 * total, msg="failed with total=%d, necVote=%d" % (total, necVote))
+            self.assertTrue(necVote > 0.5 * total, msg="failed with total={0:d}, necVote={1:d}".format(total, necVote))
 
 class UmklappTestCase(TestCase):
     def addUsers(self):
         self.users = []
         for i in range(0,7):
             u = User.objects.create_user(
-                "user%d" % i,
+                "user{0:d}".format(i),
                 "test@example.com",
                 "p455w0rd"
             )
@@ -191,7 +191,7 @@ class ViewTests(UmklappTestCase):
                                       first_sentence="first",
                                       title="foo")
             for j in range(3):
-                s.continue_story("Text %d" % j)
+                s.continue_story("Text {0:d}".format(j))
             if i >= 3:
                 s.finish()
         c = Client()
@@ -226,7 +226,7 @@ class ViewTests(UmklappTestCase):
         assert(r1.context['form'].fields.has_key("mitspieler"))
         vals = list(v for (k,v) in r1.context['form'].fields["mitspieler"].choices)
         for i in range(2,7):
-            assert("user%d" % i in vals), i
+            assert("user{0:d}".format(i) in vals), i
 
         # invalid post
         r2 = c1.post(reverse("create_new_story"),
@@ -326,7 +326,7 @@ class ViewTests(UmklappTestCase):
         assert(r.context['form'].fields.has_key("mitspieler"))
         vals = list(v for (k,v) in r.context['form'].fields["mitspieler"].choices)
         for i in range(2,7):
-            assert("user%d" % i in vals), i
+            assert("user{0:d}".format(i) in vals), i
 
         # invalid post
         r = c1.post(reverse("create_new_story"),

--- a/umklapp/views.py
+++ b/umklapp/views.py
@@ -69,7 +69,7 @@ def create_new_story(request):
             first_sentence = form.cleaned_data['firstSentence'],
             participating_users = users
             )
-        messages.success(request, u"Geschichte „%s“ gestartet" % s.title)
+        messages.success(request, u"Geschichte „{0!s}“ gestartet".format(s.title))
         return redirect('overview')
     else:
         context = {
@@ -118,11 +118,11 @@ def continue_story(request, story_id):
             if form.cleaned_data['nextSentence']:
                 s.continue_story(form.cleaned_data['nextSentence'])
             s.finish()
-            messages.success(request, u"Geschichte „%s“ beendet" % s.title)
+            messages.success(request, u"Geschichte „{0!s}“ beendet".format(s.title))
             return redirect('overview')
         else:
             s.continue_story(form.cleaned_data['nextSentence'])
-            messages.success(request, u"Geschichte „%s“ weitergeführt" % s.title)
+            messages.success(request, u"Geschichte „{0!s}“ weitergeführt".format(s.title))
             return redirect('overview')
     else:
         context = {
@@ -144,10 +144,10 @@ def leave_story(request, story_id):
         raise PermissionDenied
 
     if (s.numberOfActiveTellers() >= Story.MINIMUM_NUMBER_OF_ACTIVE_TELLERS + 1):
-        messages.success(request, u"Du hast „%s“ verlassen." % s.title)
+        messages.success(request, u"Du hast „{0!s}“ verlassen.".format(s.title))
         s.leave_story(u)
     else:
-        messages.warning(request, u"Du kannst „%s“ nicht verlassen, da sonst zu wenige Erzähler übrig blieben." % s.title)
+        messages.warning(request, u"Du kannst „{0!s}“ nicht verlassen, da sonst zu wenige Erzähler übrig blieben.".format(s.title))
     return redirect('overview')
 
 @login_required
@@ -163,9 +163,9 @@ def skip_always(request, story_id):
 
     try:
         s.set_always_skip(u)
-        messages.success(request, u"Du wirst nun automatisch übersprungen bei „%s“." % s.title)
+        messages.success(request, u"Du wirst nun automatisch übersprungen bei „{0!s}“.".format(s.title))
     except NotEnoughActivePlayers as e:
-        messages.success(request, u"Zuwenig aktive Spieler, als dass du überspringen kannst bei „%s“." % s.title)
+        messages.success(request, u"Zuwenig aktive Spieler, als dass du überspringen kannst bei „{0!s}“.".format(s.title))
     return redirect('overview')
 
 @login_required
@@ -179,7 +179,7 @@ def unskip_always(request, story_id):
     if not s.participates_in(u):
         raise PermissionDenied
 
-    messages.success(request, u"Du schreibst wieder aktiv mit bei „%s“." % s.title)
+    messages.success(request, u"Du schreibst wieder aktiv mit bei „{0!s}“.".format(s.title))
     s.unset_always_skip(u)
     return redirect('overview')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mohrm:umklapp_site?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mohrm:umklapp_site?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
